### PR TITLE
test: setup nightly workflow for fork testing

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,8 +3,8 @@ name: Nightly checks
 on:
   # workflow_dispatch so that it can be triggered manually if needed
   workflow_dispatch:
-  schedule:
-    - cron: "34 23 * * *"
+  # schedule:
+  #   - cron: "34 23 * * *"
 
 jobs:
   nightly-tests:
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         branch:
-          - main
+          - test-main
           - release-1.7
           - release-1.6
           - release-1.5


### PR DESCRIPTION
- Change matrix to test test-main instead of main
- Disable schedule (manual trigger only for testing)
- Include checkout fix: ref: ${{ matrix.branch }}

This allows testing the nightly workflow fix on fork before upstream PR.

<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
